### PR TITLE
rm zero variance ENSG00000210082.2

### DIFF
--- a/cmc-rnaseq-de/HBCC_ACC-Nirmala_FEATURECOUNTS_GRCh38_CQN_Sparse.Rmd
+++ b/cmc-rnaseq-de/HBCC_ACC-Nirmala_FEATURECOUNTS_GRCh38_CQN_Sparse.Rmd
@@ -477,6 +477,11 @@ CQN.GENE_EXPRESSION = cqn(NEW.COUNTS,
 CQN.GENE_EXPRESSION$E = CQN.GENE_EXPRESSION$y + CQN.GENE_EXPRESSION$offset
 ```
 
+Remove 0 variance gene: ENSG00000210082.2
+```{r zero_var}
+CQN.GENE_EXPRESSION$E <- subset(CQN.GENE_EXPRESSION$E, rownames(CQN.GENE_EXPRESSION$E) != "ENSG00000210082.2")
+```
+
 ### Co-expression distribution
 Coexpression of genes 
 ```{r coexp1, cache=FALSE, fig.height=5, fig.width=5}


### PR DESCRIPTION
- Remove gene that was causing 0 variance in covariate - gene correlation computation